### PR TITLE
Add in python3-pytest test dependency.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -27,6 +27,7 @@
 
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_xmllint</test_depend>
+  <test_depend>python3-pytest</test_depend>
 
   <export>
     <architecture_independent/>


### PR DESCRIPTION
This is required to run the tests, so should be explicitly declared.